### PR TITLE
Add gradient accumulation flag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,7 @@ print(f'\n✓ All {len(urls) + len(timm_models)} pretrained weight files cached!
 | `--patience` | `20` | Early stopping patience |
 | `--weight_decay` | `1e-4` | AdamW regularization |
 | `--grad_clip` | `1.0` | Gradient clipping |
+| `--grad_accum_steps` | `1` | Gradient accumulation steps (simulate larger batch sizes) |
 
 </details>
 

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -65,6 +65,7 @@ epochs: 1000                  # Maximum training epochs
 patience: 20                  # Early stopping patience (epochs without improvement)
 weight_decay: 0.0001          # L2 regularization (AdamW)
 grad_clip: 1.0                # Gradient clipping max norm
+grad_accum_steps: 1            # Gradient accumulation steps (effective batch = batch_size x steps x GPUs)
 
 # =============================================================================
 # LOSS FUNCTION

--- a/src/wavedl/train.py
+++ b/src/wavedl/train.py
@@ -1397,7 +1397,7 @@ def main():
                     optimizer.zero_grad(set_to_none=True)  # Faster than zero_grad()
 
                     # Per-batch LR scheduling (e.g., OneCycleLR)
-                    if scheduler_step_per_batch:
+                    if scheduler_step_per_batch and accelerator.sync_gradients:
                         scheduler.step()
 
                     # Accumulate as tensors to avoid .item() sync per batch

--- a/src/wavedl/train.py
+++ b/src/wavedl/train.py
@@ -260,6 +260,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--grad_clip", type=float, default=1.0, help="Gradient clipping norm"
     )
+    parser.add_argument(
+        "--grad_accum_steps",
+        type=int,
+        default=1,
+        help="Gradient accumulation steps. Effective batch = batch_size x grad_accum_steps x num_gpus",
+    )
 
     # Loss Function
     parser.add_argument(
@@ -990,6 +996,7 @@ def main():
     # Initialize Accelerator for DDP and mixed precision
     accelerator = Accelerator(
         mixed_precision=args.precision,
+        gradient_accumulation_steps=args.grad_accum_steps,
         log_with="wandb" if args.wandb and WANDB_AVAILABLE else None,
     )
     set_seed(args.seed)
@@ -1041,6 +1048,14 @@ def main():
             f"   Loss: {args.loss} | Optimizer: {args.optimizer} | Scheduler: {args.scheduler}"
         )
         logger.info(f"   Early Stopping Patience: {args.patience} epochs")
+        if args.grad_accum_steps > 1:
+            effective_bs = (
+                args.batch_size * args.grad_accum_steps * accelerator.num_processes
+            )
+            logger.info(
+                f"   Gradient Accumulation: {args.grad_accum_steps} steps "
+                f"(effective batch size: {effective_bs})"
+            )
         if args.save_every > 0:
             logger.info(f"   Periodic Checkpointing: Every {args.save_every} epochs")
         if args.resume:

--- a/src/wavedl/train.py
+++ b/src/wavedl/train.py
@@ -994,6 +994,11 @@ def main():
     # SYSTEM INITIALIZATION
     # ==========================================================================
     # Initialize Accelerator for DDP and mixed precision
+    if args.grad_accum_steps < 1:
+        raise ValueError(
+            f"--grad_accum_steps must be >= 1, got {args.grad_accum_steps}"
+        )
+
     accelerator = Accelerator(
         mixed_precision=args.precision,
         gradient_accumulation_steps=args.grad_accum_steps,

--- a/src/wavedl/utils/config.py
+++ b/src/wavedl/utils/config.py
@@ -236,6 +236,7 @@ def validate_config(
         "batch_size": (1, 10000, "Batch size should be positive"),
         "patience": (1, 1000, "Patience should be positive"),
         "cv": (0, 100, "CV folds should be 0-100"),
+        "grad_accum_steps": (1, 256, "Gradient accumulation steps should be 1-256"),
     }
 
     for key, (min_val, max_val, msg) in numeric_checks.items():

--- a/src/wavedl/utils/config.py
+++ b/src/wavedl/utils/config.py
@@ -263,6 +263,7 @@ def validate_config(
         "patience",
         "weight_decay",
         "grad_clip",
+        "grad_accum_steps",
         # Loss
         "loss",
         "huber_delta",
@@ -348,6 +349,7 @@ def create_default_config() -> dict[str, Any]:
         "patience": 20,
         "weight_decay": 1e-4,
         "grad_clip": 1.0,
+        "grad_accum_steps": 1,
         # Training components
         "loss": "mse",
         "optimizer": "adamw",

--- a/unit_tests/test_cli.py
+++ b/unit_tests/test_cli.py
@@ -59,6 +59,27 @@ class TestTrainParseArgs:
             assert args.lr == 1e-3
             assert args.optimizer == "adamw"
             assert args.scheduler == "plateau"
+            assert args.grad_accum_steps == 1
+
+    def test_grad_accum_steps_custom_value(self):
+        """Test that --grad_accum_steps parses a custom value."""
+        from wavedl.train import parse_args
+
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "wavedl-train",
+                "--model",
+                "cnn",
+                "--data_path",
+                "/fake/path.npz",
+                "--grad_accum_steps",
+                "8",
+            ],
+        ):
+            args, _ = parse_args()
+            assert args.grad_accum_steps == 8
 
     def test_model_argument(self):
         """Test that model argument is parsed correctly."""

--- a/unit_tests/test_config_metrics.py
+++ b/unit_tests/test_config_metrics.py
@@ -188,6 +188,41 @@ class TestValidateConfig:
         warnings = validate_config(config)
         assert len(warnings) == 1
 
+    def test_grad_accum_steps_zero_produces_warning(self):
+        """Test that grad_accum_steps=0 produces warning."""
+        from wavedl.utils.config import validate_config
+
+        config = {"grad_accum_steps": 0}
+        warnings = validate_config(config)
+        assert len(warnings) == 1
+        assert "Gradient accumulation" in warnings[0]
+
+    def test_grad_accum_steps_negative_produces_warning(self):
+        """Test that negative grad_accum_steps produces warning."""
+        from wavedl.utils.config import validate_config
+
+        config = {"grad_accum_steps": -1}
+        warnings = validate_config(config)
+        assert len(warnings) == 1
+        assert "Gradient accumulation" in warnings[0]
+
+    def test_grad_accum_steps_valid_no_warning(self):
+        """Test that valid grad_accum_steps produces no warning."""
+        from wavedl.utils.config import validate_config
+
+        config = {"grad_accum_steps": 4}
+        warnings = validate_config(config)
+        assert warnings == []
+
+    def test_grad_accum_steps_above_max_produces_warning(self):
+        """Test that grad_accum_steps above 256 produces warning."""
+        from wavedl.utils.config import validate_config
+
+        config = {"grad_accum_steps": 999}
+        warnings = validate_config(config)
+        assert len(warnings) == 1
+        assert "Gradient accumulation" in warnings[0]
+
 
 class TestCreateDefaultConfig:
     """Tests for default config creation."""
@@ -284,6 +319,66 @@ class TestMergeConfigWithArgs:
         merged = merge_config_with_args(config, args, ignore_unknown=True)
         assert merged.model == "cnn"
         assert not hasattr(merged, "unknown_key")
+
+
+class TestGradAccumStepsYAMLIntegration:
+    """Integration tests for grad_accum_steps loaded from YAML config."""
+
+    def test_yaml_grad_accum_steps_applied(self):
+        """Test that grad_accum_steps from YAML is applied to args."""
+        from wavedl.utils.config import load_config, merge_config_with_args
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("model: cnn\ngrad_accum_steps: 4\n")
+            f.flush()
+
+            try:
+                config = load_config(f.name)
+                args = argparse.Namespace(model="cnn", grad_accum_steps=1)
+                merged = merge_config_with_args(config, args)
+                assert merged.grad_accum_steps == 4
+            finally:
+                try:
+                    os.unlink(f.name)
+                except PermissionError:
+                    pass
+
+    def test_yaml_grad_accum_steps_validated(self):
+        """Test that invalid grad_accum_steps in YAML produces warning."""
+        from wavedl.utils.config import load_config, validate_config
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("model: cnn\ngrad_accum_steps: 0\n")
+            f.flush()
+
+            try:
+                config = load_config(f.name)
+                warnings = validate_config(config)
+                assert any("Gradient accumulation" in w for w in warnings)
+            finally:
+                try:
+                    os.unlink(f.name)
+                except PermissionError:
+                    pass
+
+    def test_yaml_grad_accum_steps_no_spurious_unknown_key_warning(self):
+        """Test that grad_accum_steps in YAML does not produce unknown key warning."""
+        from wavedl.utils.config import load_config, validate_config
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("model: cnn\ngrad_accum_steps: 4\n")
+            f.flush()
+
+            try:
+                config = load_config(f.name)
+                warnings = validate_config(config)
+                unknown_warnings = [w for w in warnings if "Unknown config key" in w]
+                assert unknown_warnings == []
+            finally:
+                try:
+                    os.unlink(f.name)
+                except PermissionError:
+                    pass
 
 
 # ==============================================================================


### PR DESCRIPTION
There's no built-in CLI flag to enable gradient accumulation. Gradient accumulation allows for simulating a larger batch size by accumulating gradients over multiple small batches before performing an optimizer step. This is a standard technique for training large models on hardware with limited memory. Without this, users can't effectively train large models on consumer GPUs with limited memory, as they are forced to use small batch sizes that might lead to unstable training.

**Recommendation**
* Add a gradient_accumulation_steps argument to the parser and update the optimizer step logic to only trigger after the specified number of steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced gradient accumulation support for memory-efficient training. Users can now configure gradient accumulation steps to increase effective batch size without proportionally increasing GPU memory requirements, selectable via CLI or configuration file.

* **Documentation**
  * Updated documentation with gradient accumulation parameter details and usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->